### PR TITLE
Improvements to kicad-fab.py

### DIFF
--- a/pcb/kicad-scripts/kicad-fab.py
+++ b/pcb/kicad-scripts/kicad-fab.py
@@ -11,8 +11,6 @@ plotDir = sys.argv[2] if len(sys.argv) > 2 else "plot/"
 
 board = LoadBoard(filename)
 
-plotDir = "plot/"
-
 pctl = PLOT_CONTROLLER(board)
 
 popt = pctl.GetPlotOptions()

--- a/pcb/kicad-scripts/kicad-fab.py
+++ b/pcb/kicad-scripts/kicad-fab.py
@@ -71,7 +71,7 @@ drlwriter.SetMapFileFormat( PLOT_FORMAT_PDF )
 
 mirror = False
 minimalHeader = False
-offset = wxPoint(0,0)
+offset = board.GetAuxOrigin()
 mergeNPTH = True   # non-plated through-hole
 drlwriter.SetOptions( mirror, minimalHeader, offset, mergeNPTH )
 


### PR DESCRIPTION
In the makefile, you can also replace `../kicad-scripts/` with `$(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))` if you're okay with GNU make (thus becoming directory depth agnostic)